### PR TITLE
options to distinguish internet, local network and localhost

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -6,7 +6,7 @@ android {
 
     defaultConfig {
         applicationId "org.ethack.orwall"
-        minSdkVersion 14
+        minSdkVersion 16
         targetSdkVersion 24
         versionCode 37
         versionName "1.0.7"

--- a/app/src/main/java/org/ethack/orwall/BootBroadcast.java
+++ b/app/src/main/java/org/ethack/orwall/BootBroadcast.java
@@ -17,6 +17,9 @@ public class BootBroadcast extends BroadcastReceiver {
 
     @Override
     public void onReceive(final Context context, final Intent intent) {
+        if (!context.getSharedPreferences(Constants.PREFERENCES, Context.MODE_PRIVATE).
+                getBoolean(Constants.PREF_KEY_ORWALL_ENABLED, true))
+            return;
 
         InitializeIptables initializeIptables = new InitializeIptables(context);
 

--- a/app/src/main/java/org/ethack/orwall/NetworkReceiver.java
+++ b/app/src/main/java/org/ethack/orwall/NetworkReceiver.java
@@ -49,8 +49,9 @@ public class NetworkReceiver extends BroadcastReceiver {
 
         if (action.equals("android.net.wifi.WIFI_STATE_CHANGED") || action.equals("android.net.conn.CONNECTIVITY_CHANGE")) {
             Log.d(TAG, "Will do some LAN stuff");
-            boolean lan_bypass = context.getSharedPreferences(Constants.PREFERENCES, Context.MODE_PRIVATE).getBoolean(Constants.PREF_KEY_LAN_ENABLED, false);
-            initializeIptables.LANPolicy(lan_bypass);
+
+            //boolean lan_bypass = context.getSharedPreferences(Constants.PREFERENCES, Context.MODE_PRIVATE).getBoolean(Constants.PREF_KEY_LAN_ENABLED, false);
+            initializeIptables.LANPolicy();
         }
     }
 }

--- a/app/src/main/java/org/ethack/orwall/UninstallBroadcast.java
+++ b/app/src/main/java/org/ethack/orwall/UninstallBroadcast.java
@@ -5,6 +5,7 @@ import android.content.Context;
 import android.content.Intent;
 import android.net.Uri;
 import android.util.Log;
+import org.ethack.orwall.lib.AppRule;
 
 import org.ethack.orwall.lib.Constants;
 import org.ethack.orwall.lib.NatRules;
@@ -34,14 +35,11 @@ public class UninstallBroadcast extends BroadcastReceiver {
             // is the app present in rules?
             NatRules natRules = new NatRules(context);
 
-            if (natRules.isAppInRules(uid)) {
+            AppRule rule = natRules.getAppRule(uid);
+            if (rule.isStored()) {
 
                 // First: remove rule from firewall if any
-                Intent bgpProcess = new Intent(context, BackgroundProcess.class);
-                bgpProcess.putExtra(Constants.PARAM_APPNAME, appName);
-                bgpProcess.putExtra(Constants.PARAM_APPUID, uid);
-                bgpProcess.putExtra(Constants.ACTION, Constants.ACTION_RM_RULE);
-                context.startService(bgpProcess);
+                rule.uninstall(context);
 
                 // Second: remove app from NatRules if present
                 natRules.removeAppFromRules(uid);

--- a/app/src/main/java/org/ethack/orwall/database/natDBHelper.java
+++ b/app/src/main/java/org/ethack/orwall/database/natDBHelper.java
@@ -16,22 +16,23 @@ public class natDBHelper extends SQLiteOpenHelper {
     public static final String COLUMN_APPUID = "appUID";
     public static final String COLUMN_APPNAME = "appName";
     public static final String COLUMN_ONIONTYPE = "onionType";
-    public static final String COLUMN_ONIONPORT = "onionPort";
-    public static final String COLUMN_PORTTYPE = "portType";
+    public static final String COLUMN_LOCALHOST = "localhost";
+    public static final String COLUMN_LOCALNETWORK = "localnetwork";
+
     private static final String NAT_TABLE_CREATE =
             String.format(
                     "CREATE TABLE %s (" +
                             "%s INTEGER PRIMARY KEY," +
                             "%s TEXT NOT NULL," +
-                            "%s TEXT NOT NULL DEFAULT \"%s\"," +
-                            "%s INTEGER NOT NULL DEFAULT '%d'," +
-                            "%s TEXT NOT NULL DEFAULT \"TransProxy\")",
+                            "%s TEXT," +
+                            "%s INTEGER," +
+                            "%s INTEGER)",
                     NAT_TABLE_NAME,
                     COLUMN_APPUID,
                     COLUMN_APPNAME,
-                    COLUMN_ONIONTYPE, Constants.DB_ONION_TYPE_TOR,
-                    COLUMN_ONIONPORT, Constants.ORBOT_TRANSPROXY,
-                    COLUMN_PORTTYPE
+                    COLUMN_ONIONTYPE,
+                    COLUMN_LOCALHOST,
+                    COLUMN_LOCALNETWORK
             );
     private static final int DATABASE_VERSION = 1;
     private static final String DB_NAME = "nat.s3db";

--- a/app/src/main/java/org/ethack/orwall/database/natDBHelper.java
+++ b/app/src/main/java/org/ethack/orwall/database/natDBHelper.java
@@ -1,6 +1,8 @@
 package org.ethack.orwall.database;
 
+import android.content.ContentValues;
 import android.content.Context;
+import android.database.Cursor;
 import android.database.sqlite.SQLiteDatabase;
 import android.database.sqlite.SQLiteOpenHelper;
 
@@ -19,7 +21,31 @@ public class natDBHelper extends SQLiteOpenHelper {
     public static final String COLUMN_LOCALHOST = "localhost";
     public static final String COLUMN_LOCALNETWORK = "localnetwork";
 
-    private static final String NAT_TABLE_CREATE =
+    @Deprecated
+    private static final String COLUMN_PORTTYPE = "portType";
+    @Deprecated
+    private static final String DB_PORT_TYPE_FENCED = "Fenced";
+/*
+    @Deprecated
+    private static final String COLUMN_ONIONPORT = "onionPort";
+
+    private static final String NAT_TABLE_CREATE_V1 =
+            String.format(
+                    "CREATE TABLE %s (" +
+                            "%s INTEGER PRIMARY KEY," +
+                            "%s TEXT NOT NULL," +
+                            "%s TEXT NOT NULL DEFAULT \"%s\"," +
+                            "%s INTEGER NOT NULL DEFAULT '%d'," +
+                            "%s TEXT NOT NULL DEFAULT \"TransProxy\")",
+                    NAT_TABLE_NAME,
+                    COLUMN_APPUID,
+                    COLUMN_APPNAME,
+                    COLUMN_ONIONTYPE, Constants.DB_ONION_TYPE_TOR,
+                    COLUMN_ONIONPORT, Constants.ORBOT_TRANSPROXY,
+                    COLUMN_PORTTYPE
+            );
+*/
+    private static final String NAT_TABLE_CREATE_V2 =
             String.format(
                     "CREATE TABLE %s (" +
                             "%s INTEGER PRIMARY KEY," +
@@ -34,7 +60,8 @@ public class natDBHelper extends SQLiteOpenHelper {
                     COLUMN_LOCALHOST,
                     COLUMN_LOCALNETWORK
             );
-    private static final int DATABASE_VERSION = 1;
+
+    private static final int DATABASE_VERSION = 2;
     private static final String DB_NAME = "nat.s3db";
 
     public natDBHelper(Context context) {
@@ -43,11 +70,62 @@ public class natDBHelper extends SQLiteOpenHelper {
 
     @Override
     public void onCreate(SQLiteDatabase db) {
-        db.execSQL(NAT_TABLE_CREATE);
+        db.execSQL(NAT_TABLE_CREATE_V2);
     }
 
     @Override
     public void onUpgrade(SQLiteDatabase db, int oldVersion, int newVersion) {
-        return;
+        if (oldVersion == newVersion){
+            return;
+        }
+
+        db.beginTransaction();
+        try{
+            for(int version = oldVersion; version < newVersion; version++){
+                switch (version){
+                    // VERSION 1 -----> 2
+                    case 1:
+                        db.execSQL(String.format("ALTER TABLE %s RENAME TO %s_backup;", NAT_TABLE_NAME, NAT_TABLE_NAME));
+                        db.execSQL(NAT_TABLE_CREATE_V2);
+
+                        String[] selection = {
+                                COLUMN_APPUID,
+                                COLUMN_APPNAME,
+                                COLUMN_ONIONTYPE,
+                                COLUMN_PORTTYPE
+                        };
+                        Cursor cursor = db.query(NAT_TABLE_NAME + "_backup", selection, null, null, null, null, null);
+                        if (cursor.moveToFirst()) {
+                            ContentValues data = new ContentValues();
+                            String porType;
+                            do {
+                                data.put(COLUMN_APPUID, cursor.getLong(0));
+                                data.put(COLUMN_APPNAME, cursor.getString(1));
+                                data.put(COLUMN_ONIONTYPE, cursor.getString(2));
+                                porType = cursor.getString(3);
+                                // fenced was localhost (output)
+                                if (porType != null && porType.equals(DB_PORT_TYPE_FENCED)){
+                                    data.put(COLUMN_LOCALHOST, 1);
+                                } else {
+                                    data.put(COLUMN_LOCALHOST, 0);
+                                }
+                                data.put(COLUMN_LOCALNETWORK, 0);
+
+                                db.insert(NAT_TABLE_NAME, null, data);
+
+                            } while (cursor.moveToNext());
+                        }
+                        cursor.close();
+
+                        db.execSQL(String.format("DROP TABLE %s_backup;", NAT_TABLE_NAME));
+                        break;
+                }
+            }
+
+            db.setTransactionSuccessful();
+        } finally{
+            db.endTransaction();
+        }
     }
+
 }

--- a/app/src/main/java/org/ethack/orwall/database/natDBHelper.java
+++ b/app/src/main/java/org/ethack/orwall/database/natDBHelper.java
@@ -22,12 +22,12 @@ public class natDBHelper extends SQLiteOpenHelper {
     public static final String COLUMN_LOCALNETWORK = "localnetwork";
 
     @Deprecated
-    private static final String COLUMN_PORTTYPE = "portType";
+    private static final String COLUMN_ONIONPORT = "onionPort";
     @Deprecated
     private static final String DB_PORT_TYPE_FENCED = "Fenced";
 /*
     @Deprecated
-    private static final String COLUMN_ONIONPORT = "onionPort";
+    private static final String COLUMN_PORTTYPE = "portType";
 
     private static final String NAT_TABLE_CREATE_V1 =
             String.format(
@@ -87,38 +87,11 @@ public class natDBHelper extends SQLiteOpenHelper {
                     case 1:
                         db.execSQL(String.format("ALTER TABLE %s RENAME TO %s_backup;", NAT_TABLE_NAME, NAT_TABLE_NAME));
                         db.execSQL(NAT_TABLE_CREATE_V2);
-
-                        String[] selection = {
-                                COLUMN_APPUID,
-                                COLUMN_APPNAME,
-                                COLUMN_ONIONTYPE,
-                                COLUMN_PORTTYPE
-                        };
-                        Cursor cursor = db.query(NAT_TABLE_NAME + "_backup", selection, null, null, null, null, null);
-                        if (cursor.moveToFirst()) {
-                            ContentValues data = new ContentValues();
-                            String porType;
-                            do {
-                                data.put(COLUMN_APPUID, cursor.getLong(0));
-                                data.put(COLUMN_APPNAME, cursor.getString(1));
-                                data.put(COLUMN_ONIONTYPE, cursor.getString(2));
-                                porType = cursor.getString(3);
-                                // fenced was localhost (output)
-                                if (porType != null && porType.equals(DB_PORT_TYPE_FENCED)){
-                                    data.put(COLUMN_LOCALHOST, 1);
-                                } else {
-                                    data.put(COLUMN_LOCALHOST, 0);
-                                }
-                                data.put(COLUMN_LOCALNETWORK, 0);
-
-                                db.insert(NAT_TABLE_NAME, null, data);
-
-                            } while (cursor.moveToNext());
-                        }
-                        cursor.close();
-
+                        db.execSQL(String.format(
+                                "INSERT INTO %s(%s, %s, %s, %s, %s) SELECT %s, %s, %s, 0, 0 FROM %s_backup;",
+                                NAT_TABLE_NAME, COLUMN_APPUID, COLUMN_APPNAME, COLUMN_ONIONTYPE, COLUMN_LOCALHOST, COLUMN_LOCALNETWORK,
+                                                COLUMN_APPUID, COLUMN_APPNAME, COLUMN_ONIONTYPE, NAT_TABLE_NAME));
                         db.execSQL(String.format("DROP TABLE %s_backup;", NAT_TABLE_NAME));
-                        break;
                 }
             }
 

--- a/app/src/main/java/org/ethack/orwall/fragments/AppFragment.java
+++ b/app/src/main/java/org/ethack/orwall/fragments/AppFragment.java
@@ -127,7 +127,7 @@ public class AppFragment extends Fragment {
         for (PackageInfo pkgInfo : pkgInstalled) {
             if (needInternet(pkgInfo) && !isReservedApp(pkgInfo)) {
                 if (!natRules.isAppInRules((long) pkgInfo.applicationInfo.uid)) {
-                    pkgList.add(new AppRule(pkgInfo.packageName, (long) pkgInfo.applicationInfo.uid, "None", (long) 0, "None"));
+                    pkgList.add(new AppRule(pkgInfo.packageName, (long) pkgInfo.applicationInfo.uid, Constants.DB_ONION_TYPE_NONE, false, false));
                 }
             }
         }
@@ -141,7 +141,7 @@ public class AppFragment extends Fragment {
 
         for (PackageInfoData pkgInfo: specialApps.values()) {
             if (!natRules.isAppInRules(pkgInfo.getUid())) {
-                pkgList.add(new AppRule(pkgInfo.getPkgName(), pkgInfo.getUid(), "None", (long) 0, "None"));
+                pkgList.add(new AppRule(pkgInfo.getPkgName(), pkgInfo.getUid(), Constants.DB_ONION_TYPE_NONE, false, false));
             }
         }
 

--- a/app/src/main/java/org/ethack/orwall/fragments/HomeFragment.java
+++ b/app/src/main/java/org/ethack/orwall/fragments/HomeFragment.java
@@ -64,7 +64,6 @@ public class HomeFragment extends Fragment {
         Switch orwallStatus = (Switch) view.findViewById(R.id.orwall_status);
         Switch browserStatus = (Switch) view.findViewById(R.id.browser_status);
         Switch sipStatus = (Switch) view.findViewById(R.id.sip_status);
-        Switch lanStatus = (Switch) view.findViewById(R.id.lan_status);
         Switch tetherStatus = (Switch) view.findViewById(R.id.tethering_status);
 
         // Status switches — most of them are read-only, as they just displays devices capabilities.
@@ -129,16 +128,6 @@ public class HomeFragment extends Fragment {
             sipStatus.setClickable(false);
             sipStatus.setTextColor(Color.GRAY);
         }
-
-        lanStatus.setChecked(sharedPreferences.getBoolean(Constants.PREF_KEY_LAN_ENABLED, false));
-        lanStatus.setOnClickListener(new View.OnClickListener() {
-            @Override
-            public void onClick(View view) {
-                boolean checked = ((Switch) view).isChecked();
-                initializeIptables.LANPolicy(checked);
-                sharedPreferences.edit().putBoolean(Constants.PREF_KEY_LAN_ENABLED, checked).apply();
-            }
-        });
 
         tetherStatus.setChecked(sharedPreferences.getBoolean(Constants.PREF_KEY_TETHER_ENABLED, false));
         tetherStatus.setOnClickListener(new View.OnClickListener() {

--- a/app/src/main/java/org/ethack/orwall/lib/AppRule.java
+++ b/app/src/main/java/org/ethack/orwall/lib/AppRule.java
@@ -1,15 +1,25 @@
 package org.ethack.orwall.lib;
 
+import android.content.Context;
+import android.content.Intent;
+import android.content.pm.ApplicationInfo;
+import android.content.pm.PackageManager;
+import android.provider.SyncStateContract;
+
+import org.ethack.orwall.BackgroundProcess;
+import org.ethack.orwall.lib.PackageInfoData;
+import java.util.ArrayList;
+
 /**
  * Data structure: application NAT rule.
  */
 public class AppRule {
-
+    private Boolean stored;
     private String pkgName;
     private Long appUID;
     private String onionType;
-    private Long onionPort;
-    private String portType;
+    private Boolean localHost;
+    private Boolean localNetwork;
 
     // Variables dedicated for ListView
     // We need them for persistence across scroll
@@ -17,12 +27,13 @@ public class AppRule {
     private String label;
     private String appName;
 
-    public AppRule(String pkgName, Long appUID, String onionType, Long onionPort, String portType) {
+    public AppRule(String pkgName, Long appUID, String onionType, Boolean localHost, Boolean localNetwork) {
+        this.stored = true;
         this.pkgName = pkgName;
         this.appUID = appUID;
         this.onionType = onionType;
-        this.onionPort = onionPort;
-        this.portType = portType;
+        this.localHost = localHost;
+        this.localNetwork = localNetwork;
         // set to a null value - used in AppListAdapter
         this.label = null;
         this.appName = null;
@@ -30,8 +41,24 @@ public class AppRule {
 
     public AppRule() {
         // Empty constructor in order to use setters.
+        this.stored = false;
+        this.pkgName = null;
+        this.appUID = null;
+        this.onionType = Constants.DB_ONION_TYPE_NONE;
+        this.localHost = false;
+        this.localNetwork = false;
+        // set to a null value - used in AppListAdapter
+        this.label = null;
+        this.appName = null;
     }
 
+    public Boolean isStored(){
+        return this.stored;
+    }
+
+    public Boolean isEmpty(){
+        return !this.localHost && !this.localNetwork && this.onionType.equals(Constants.DB_ONION_TYPE_NONE);
+    }
 
     public String getPkgName() {
         return this.pkgName;
@@ -45,16 +72,54 @@ public class AppRule {
         return this.onionType;
     }
 
+    public String getDisplay(){
+        String ret = this.appName;
+        ArrayList<String> flags = new ArrayList<>();
+        switch (this.onionType) {
+            case Constants.DB_ONION_TYPE_NONE:
+                break;
+            case Constants.DB_ONION_TYPE_BYPASS:
+                flags.add("Bypass");
+                break;
+            case Constants.DB_ONION_TYPE_TOR:
+                flags.add("Tor");
+                break;
+        }
+        if (this.localHost) {
+            flags.add("Localhost");
+        }
+        if (this.localNetwork) {
+            flags.add("LocalNetwork");
+        }
+
+        if (!flags.isEmpty()){
+            ret += " (" + flags.get(0);
+            for(int i = 1; i < flags.size(); i++){
+                ret += " - " + flags.get(i);
+            }
+            ret += ")";
+        }
+        return ret;
+    }
+
     public void setOnionType(String onionType) {
         this.onionType = onionType;
     }
 
-    public String getPortType() {
-        return this.portType;
+    public Boolean getLocalHost() {
+        return this.localHost;
     }
 
-    public void setPortType(String portType) {
-        this.portType = portType;
+    public void setLocalHost(Boolean localHost) {
+        this.localHost = localHost;
+    }
+
+    public Boolean getLocalNetwork() {
+        return this.localNetwork;
+    }
+
+    public void setLocalNetwork(Boolean localNetwork) {
+        this.localNetwork = localNetwork;
     }
 
     public Long getAppUID() {
@@ -63,14 +128,6 @@ public class AppRule {
 
     public void setAppUID(Long appUID) {
         this.appUID = appUID;
-    }
-
-    public Long getOnionPort() {
-        return this.onionPort;
-    }
-
-    public void setOnionPort(Long onionPort) {
-        this.onionPort = onionPort;
     }
 
     /**
@@ -99,6 +156,36 @@ public class AppRule {
 
     public void setAppName(String appName) {
         this.appName = appName;
+    }
+
+    private Intent newBackground(Context context, Intent intent){
+        Intent bg = (intent == null? new Intent(context, BackgroundProcess.class): intent);
+        bg.putExtra(Constants.PARAM_APPUID, getAppUID());
+        bg.putExtra(Constants.PARAM_APPNAME, getPkgName());
+        bg.putExtra(Constants.PARAM_ONIONTYPE, getOnionType());
+        bg.putExtra(Constants.PARAM_LOCALHOST, getLocalHost());
+        bg.putExtra(Constants.PARAM_LOCALNETWORK, getLocalNetwork());
+        return bg;
+    }
+
+    public void install(Context context, Intent intent){
+        Intent bg = newBackground(context, intent);
+        bg.putExtra(Constants.ACTION, Constants.ACTION_ADD_RULE);
+        context.startService(bg);
+    }
+
+    public void uninstall(Context context, Intent intent){
+        Intent bg = newBackground(context, intent);
+        bg.putExtra(Constants.ACTION, Constants.ACTION_RM_RULE);
+        context.startService(bg);
+    }
+
+    public void install(Context context){
+        install(context, null);
+    }
+
+    public void uninstall(Context context){
+        uninstall(context, null);
     }
 
 }

--- a/app/src/main/java/org/ethack/orwall/lib/Constants.java
+++ b/app/src/main/java/org/ethack/orwall/lib/Constants.java
@@ -25,7 +25,6 @@ public class Constants {
     public final static String PREF_KEY_BROWSER_GRACETIME = "browser_gracetime";
     public final static String CONFIG_IPT_SUPPORTS_COMMENTS = "ipt_comments";
     public final static String PREF_KEY_ORWALL_ENABLED = "orwall_enabled";
-    public final static String PREF_KEY_LAN_ENABLED = "lan_enabled";
     public final static String PREF_KEY_CURRENT_SUBNET = "current_subnet";
     public final static String PREF_KEY_HIDE_PRESS_HINT = "hide_press_hint";
 
@@ -39,19 +38,17 @@ public class Constants {
 
     public final static String ACTION_ADD_RULE = "org.ethack.orwall.backgroundProcess.action.addRule";
     public final static String ACTION_RM_RULE = "org.ethack.orwall.backgroundProcess.action.rmRule";
-    public final static String PARAM_APPUID = "org.ethack.orwall.backgroundProcess.action.addRule.appUid";
-    public final static String PARAM_APPNAME = "org.ethack.orwall.backgroundProcess.action.addRule.appName";
+    public final static String PARAM_APPUID = "org.ethack.orwall.backgroundProcess.action.rule.appUid";
+    public final static String PARAM_APPNAME = "org.ethack.orwall.backgroundProcess.action.rule.appName";
+    public final static String PARAM_LOCALHOST = "org.ethack.orwall.backgroundProcess.action.rule.localHost";
+    public final static String PARAM_LOCALNETWORK = "org.ethack.orwall.backgroundProcess.action.rule.localNetwork";
+    public final static String PARAM_ONIONTYPE = "org.ethack.orwall.backgroundProcess.action.rule.onionType";
 
     public final static String ACTION_TETHER = "org.ethack.orwall.backgroundProcess.action.tethering";
     public final static String PARAM_TETHER_STATUS = "org.ethack.orwall.backgroundProcess.action.tethering.status";
 
     public final static String ACTION_DISABLE_ORWALL = "org.ethack.orwall.backgroundProcess.action.disable_orwall";
     public final static String ACTION_ENABLE_ORWALL = "org.ethack.orwall.backgroundProcess.action.enable_orwall";
-
-    public final static String ACTION_RM_FENCED = "org.ethack.orwall.backgroundProcess.action.rmFenced";
-    public final static String ACTION_RM_BYPASS = "org.ethack.orwall.backgroundProcess.action.rmBypass";
-    public final static String ACTION_ADD_FENCED = "org.ethack.orwall.backgroundProcess.action.addFenced";
-    public final static String ACTION_ADD_BYPASS = "org.ethack.orwall.backgroundProcess.action.addBypass";
 
     public final static long ORBOT_SOCKS_PROXY = 9050;
     public final static long ORBOT_TRANSPROXY = 9040;
@@ -65,7 +62,7 @@ public class Constants {
 
     public final static String DB_PORT_TYPE_TRANS = "TransProxy";
     public final static String DB_PORT_TYPE_SOCKS = "SOCKS";
-    public final static String DB_PORT_TYPE_FENCED = "Fenced";
+    public final static String DB_ONION_TYPE_NONE = "None";
     public final static String DB_ONION_TYPE_TOR = "Tor";
     public final static String DB_ONION_TYPE_I2P = "i2p";
     public final static String DB_ONION_TYPE_BYPASS = "Bypass";

--- a/app/src/main/res/layout/about.xml
+++ b/app/src/main/res/layout/about.xml
@@ -7,7 +7,7 @@
 
     <LinearLayout
         android:layout_width="fill_parent"
-        android:layout_height="fill_parent"
+        android:layout_height="wrap_content"
         android:layout_marginBottom="15dp"
         android:orientation="vertical">
 

--- a/app/src/main/res/layout/advanced_connection.xml
+++ b/app/src/main/res/layout/advanced_connection.xml
@@ -10,12 +10,28 @@
         android:layout_width="fill_parent"
         android:layout_height="wrap_content">
 
-        <TextView
-            android:layout_width="fill_parent"
+        <CheckBox
+            android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:padding="5dp"
-            android:text="@string/advanced_connection_provider"
-            android:textSize="20sp" />
+            android:text="Internet"
+            android:id="@+id/id_check_internet"
+            android:checked="false" />
+
+        <RadioButton
+            android:layout_width="329dp"
+            android:layout_height="wrap_content"
+            android:text="Tor"
+            android:id="@+id/id_radio_tor"
+            android:checked="false"
+            android:layout_marginLeft="30dp" />
+
+        <RadioButton
+            android:layout_width="329dp"
+            android:layout_height="wrap_content"
+            android:text="@string/advanced_connection_bypass"
+            android:id="@+id/id_radio_bypass"
+            android:checked="false"
+            android:layout_marginLeft="30dp" />
 
     </RadioGroup>
 
@@ -24,29 +40,21 @@
         android:layout_width="fill_parent"
         android:layout_height="wrap_content">
 
-        <TextView
-            android:layout_width="fill_parent"
-            android:layout_height="wrap_content"
-            android:padding="5dp"
-            android:text="@string/advanced_connection_type"
-            android:textSize="20sp" />
 
-        <RadioButton
-            android:id="@+id/id_radio_force"
-            android:layout_width="fill_parent"
-            android:layout_height="wrap_content"
-            android:text="@string/advanced_connection_type_force" />
-
-        <RadioButton
-            android:id="@+id/id_radio_fenced"
-            android:layout_width="fill_parent"
-            android:layout_height="wrap_content"
-            android:text="@string/advanced_connection_type_native" />
     </RadioGroup>
 
     <CheckBox
-        android:id="@+id/id_checkbox_bypass"
-        android:layout_width="fill_parent"
+        android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:text="@string/advanced_connection_bypass" />
+        android:text="Localhost"
+        android:id="@+id/id_check_localhost"
+        android:checked="false" />
+
+    <CheckBox
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="Local network"
+        android:id="@+id/id_check_localnetwork"
+        android:checked="false" />
+
 </LinearLayout>

--- a/app/src/main/res/layout/fragment_tabbed_home.xml
+++ b/app/src/main/res/layout/fragment_tabbed_home.xml
@@ -84,15 +84,6 @@
                 android:textOff="@string/disabled"
                 android:textOn="@string/enabled" />
 
-            <Switch
-                android:id="@+id/lan_status"
-                android:layout_width="fill_parent"
-                android:layout_height="wrap_content"
-                android:layout_marginBottom="10dp"
-                android:text="@string/switch_lan"
-                android:textOff="@string/disabled"
-                android:textOn="@string/enabled" />
-
             <Space
                 android:layout_width="fill_parent"
                 android:layout_height="30dp" />

--- a/app/src/main/res/layout/fragment_tabbed_logs.xml
+++ b/app/src/main/res/layout/fragment_tabbed_logs.xml
@@ -10,5 +10,5 @@
         android:layout_centerInParent="true"
         android:gravity="center"
         android:text="Logs"
-        android:textSize="20dp" />
+        android:textSize="20sp" />
 </RelativeLayout>

--- a/app/src/main/res/layout/fragment_tabbed_noapps.xml
+++ b/app/src/main/res/layout/fragment_tabbed_noapps.xml
@@ -10,5 +10,5 @@
         android:layout_centerInParent="true"
         android:gravity="center"
         android:text="@string/notification_deactivated_title"
-        android:textSize="20dp" />
+        android:textSize="20sp" />
 </RelativeLayout>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -104,7 +104,7 @@
   <string name="advanced_connection_type">Art der Verbindung</string>
   <string name="advanced_connection_type_force">Erzwingen Verbindung (mit REDIRECT)</string>
   <string name="advanced_connection_type_native">Verwendung Anwendung native Kapazität (eingezäunt Pfad)</string>
-  <string name="advanced_connection_bypass">Lassen Sie diese Anwendung, um den Proxy zu umgehen</string>
+  <string name="advanced_connection_bypass">Umgehen den Proxy</string>
   <string name="alert_save">Registrieren</string>
   <string name="alert_cancel">Stornieren</string>
 

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -97,7 +97,7 @@
     <string name="advanced_connection_type">Tipo de conexión</string>
     <string name="advanced_connection_type_force">Forzar la conexión (usando REDIRECCIONAMIENTO)</string>
     <string name="advanced_connection_type_native">Usar la capacidad nativa de la aplicación (Camino cerrado)</string>
-    <string name="advanced_connection_bypass">Permitir a la aplicación evitar el Proxy</string>
+    <string name="advanced_connection_bypass">Evitar el Proxy</string>
     <string name="alert_save">Guardar</string>
     <string name="alert_cancel">Cancelar</string>
 

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -104,11 +104,11 @@
     <string name="advanced_connection_type">Type de connexion</string>
     <string name="advanced_connection_type_force">Forcer connexion (utilise REDIRECT)</string>
     <string name="advanced_connection_type_native">Utiliser les capacités natives de l\'application (Chemin clôturé)</string>
-    <string name="advanced_connection_bypass">Autoriser cette application à passer outre le proxy</string>
+    <string name="advanced_connection_bypass">Passer outre le proxy</string>
     <string name="alert_save">Enregistrer</string>
     <string name="alert_cancel">Annuler</string>
 
-    <string name="start_wizard">Démarrer l\'assistant</string>
+    <string name="start_wizard">Assistant</string>
     <string name="wizard_step">Étape</string>
     <string name="wizard_title_one">Qu\'est-ce qu\'orWall</string>
     <string name="wizard_title_two">Réglages rapides</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -97,7 +97,7 @@ In questo caso non possiamo farci niente :(.
 <string name="advanced_connection_type">Tipo de connessione</string>
 <string name="advanced_connection_type_force">Imporre connessione (utilizza REDIRECT)</string>
 <string name="advanced_connection_type_native">Utilizzare le funzionalità native dell\'applicazione (Percorso recintato)</string>
-<string name="advanced_connection_bypass">Permettre a questa applicazione d\' oltrepassare il proxy</string>
+<string name="advanced_connection_bypass">Bypassare il proxy</string>
 <string name="alert_save">Registrare</string>
 <string name="alert_cancel">Cancellare</string>
 <string name="start_wizard">Avvia procedura guidata</string>

--- a/app/src/main/res/values/no_translation.xml
+++ b/app/src/main/res/values/no_translation.xml
@@ -3,7 +3,7 @@
     <string name="app_name" translatable="false">orWall</string>
 
     <string name="about_links" translatable="false">
-        https://orwall.org \nhttps://twitter.com/orWallApp \nhttps://github.com/hgourvest/orWall
+        https://orwall.org \nhttps://twitter.com/orWallApp \nhttps://github.com/EthACKdotOrg/orWall
     </string>
         <string name="about_author_list" translatable="false">
         EthACK (https://www.ethack.org) \nSwissTengu (https://www.swisstengu.ch) \nHenri Gourvest(hgourvest@progdigy.com)

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -97,7 +97,7 @@
     <string name="advanced_connection_type">Connection type</string>
     <string name="advanced_connection_type_force">Force connection (using REDIRECT)</string>
     <string name="advanced_connection_type_native">Use application native capacity (Fenced path)</string>
-    <string name="advanced_connection_bypass">Allow this application to bypass Proxy</string>
+    <string name="advanced_connection_bypass">Bypass Proxy</string>
     <string name="alert_save">Save</string>
     <string name="alert_cancel">Cancel</string>
 


### PR DESCRIPTION
- removed « fenced » option, use « localhost » instead (bidirectionnal)
- removed general LAN option, you can now activate this option
individually (bidirectionnal).
- bypass option no longer give access to LAN and localhost, you must
check localhost and local network option to have the old behavior.
- various cleanup, attempt to fix UI bugs …